### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ used (`[1, 2, ...etc]`), in which case the array must be at least as long as the
 number of entries before the rest param.
 
 Array destructuring supports using a custom matcher, just like Objects. When
-using custom matchers, the value is destructures as an `Array-like` object, so
+using custom matchers, the value is destructured as an `Array-like` object, so
 it doesn't need to be a subclass of `Array` -- the `length` property will be
 used for destructuring, along with any numerical keys.
 
@@ -779,8 +779,8 @@ function ByVal (obj) {
 }
 
 match (x) {
-  ByVal(c.FOO) x => 'got a FOO',
-  ByVal(c.BAR) x => 'got a BAR'
+  ByVal(FOO) x => 'got a FOO',
+  ByVal(BAR) x => 'got a BAR'
 }
 ```
 
@@ -794,7 +794,7 @@ would have limited utility.)
 
 #### <a name="unbound-array-rest"></a> Binding-less array rest
 
-In ECMAScript, `var [a, b, ...rest] = arr` allows bindging of "the rest" of the
+In ECMAScript, `var [a, b, ...rest] = arr` allows binding of "the rest" of the
 array into a variable. This syntax, though, requires that the "rest" value be
 bound to a specific variable. That is, `[a, b, ...]` is invalid syntax.
 


### PR DESCRIPTION
Changes:
- is destructures -> is destructured
- `c.FOO` -> `FOO` and `c.BAR` -> `BAR` because they were imported with `{FOO, BAR}`
- bindging -> binding
- I assume you meant iff instead of if in `Symbol.patternMatch` Option A